### PR TITLE
Added locals to assume output

### DIFF
--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -1,25 +1,31 @@
 import pytest
 import inspect
 import os.path
+from py.io import saferepr
 
 def pytest_namespace():
     def assume(expr, msg=''):
         if not expr:
             # get filename, line, and context
-            (filename, line, funcname, contextlist) = inspect.stack()[1][1:5]
+            (frame, filename, line, funcname, contextlist) = inspect.stack()[1][0:5]
             filename = os.path.relpath(filename)
             context = contextlist[0]
             # format entry
             msg = '%s\n' % msg if msg else ''
-            entry = '>%s%s%s:%s\n--------' % (context, msg, filename, line)
+            entry = '>%s%s%s:%s\n' % (context, msg, filename, line)
             # add entry
             pytest._failed_assumptions.append(entry)
+            pretty_locals = ["%-10s = %s" %(name, saferepr(val))
+                             for name, val in frame.f_locals.items()]
+            pytest._assumption_locals.append(pretty_locals)
 
-    return {'_failed_assumptions': [],
+    return {'_assumption_locals': [],
+            '_failed_assumptions': [],
             'assume': assume}
 
 def pytest_runtest_setup(item):
     del pytest._failed_assumptions[:]
+    del pytest._assumption_locals[:]
 
 @pytest.mark.hookwrapper
 def pytest_runtest_makereport(item, call):
@@ -27,11 +33,14 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
     if call.when == "call" and pytest._failed_assumptions:
         summary = 'Failed Assumptions:%s' % len(pytest._failed_assumptions)
-        pytest._failed_assumptions.append(summary)
         if report.longrepr:
-            report.longrepr = str(report.longrepr) + \
-                              '\n--------\n' + ('\n'.join(pytest._failed_assumptions))
+            report.sections.append((summary, "\n".join(pytest._failed_assumptions)))
         else:
-            report.longrepr = '\n'.join(pytest._failed_assumptions)
+            assume_data = zip(pytest._failed_assumptions, pytest._assumption_locals)
+            longrepr = ["{}\n{}".format(assumption, "\n".join(locals))
+                        for assumption, locals in assume_data]
+            longrepr.append("-" * 40)
+            longrepr.append(summary)
+            report.longrepr = '\n'.join(longrepr)
         report.outcome = "failed"
 


### PR DESCRIPTION
Note: this last commit is rather experimental, and a bit ugly. 

In short, we try to replicate py.test's method of outputting locals.
It really should respect pytest's show_locals, but right now it doesn't.

If there's been an exception, simply add our failed assumptions to the longrepr section. Otherwise, build out our own longrepr.