### PR TITLE
Add return value to pytest.assume()

### DIFF
--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -45,6 +45,10 @@ def assume(expr, msg=''):
                              for name, val in frame.f_locals.items()]
             _ASSUMPTION_LOCALS.append(pretty_locals)
 
+        return False
+    else:
+        return True
+
 
 def pytest_configure(config):
     """


### PR DESCRIPTION
Added return value to pytest.assume() call
This will really be helpful when a decision needs to be taken based on multiple assume combinations for any test