### PR TITLE
Handle failed assumptions and errors in setup / fixtures

### DIFF
--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -194,6 +194,7 @@ def pytest_fixture_setup(fixturedef, request):
 
 def handle_assumptions(outcome, in_setup=False):
     """Look for and process failed assumptions from setup or test execution."""
+    __traceback_hide__ = True
     failed_assumptions = _FAILED_ASSUMPTIONS
     if failed_assumptions:
         failed_count = len(failed_assumptions)

--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -179,7 +179,7 @@ def pytest_pyfunc_call(pyfuncitem):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_setup(item):
+def pytest_fixture_setup(fixturedef, request):
     """
     Need to make sure we process failed assumptions of setup failure as well, since pytest_pyfunc_call
     does not get called if there's a setup failure.  Otherwise, failed assumptions will carry over to the
@@ -191,7 +191,6 @@ def pytest_runtest_setup(item):
         outcome = yield
     finally:
         handle_assumptions(outcome)
-
 
 def handle_assumptions(outcome):
     failed_assumptions = _FAILED_ASSUMPTIONS

--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -162,7 +162,14 @@ def pytest_assume_pass(lineno, entry):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_setup(item):
+def pytest_pyfunc_call(pyfuncitem):
+    """
+    Using pyfunc_call to be as 'close' to the actual call of the test as possible.
+
+    This is executed immediately after the test itself is called.
+
+    Note: I'm not happy with exception handling in here.
+    """
     __tracebackhide__ = True
     outcome = None
     try:
@@ -172,13 +179,11 @@ def pytest_runtest_setup(item):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_pyfunc_call(pyfuncitem):
+def pytest_runtest_setup(item):
     """
-    Using pyfunc_call to be as 'close' to the actual call of the test as possible.
-
-    This is executed immediately after the test itself is called.
-
-    Note: I'm not happy with exception handling in here.
+    Need to make sure we process failed assumptions of setup failure as well, since pytest_pyfunc_call
+    does not get called if there's a setup failure.  Otherwise, failed assumptions will carry over to the
+    next test case and the next test case will appear to fail with the previous test's failed assumptions.
     """
     __tracebackhide__ = True
     outcome = None

--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -192,6 +192,7 @@ def pytest_fixture_setup(fixturedef, request):
     finally:
         handle_assumptions(outcome, in_setup=True)
 
+
 def handle_assumptions(outcome, in_setup=False):
     """Look for and process failed assumptions from setup or test execution."""
     __tracebackhide__ = True
@@ -224,5 +225,3 @@ def handle_assumptions(outcome, in_setup=False):
             exc = FailedAssumption(root_msg + "\n" + content)
             # Note: raising here so that we guarantee a failure.
             raise_(FailedAssumption, exc, last_tb)
-
-

--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -181,7 +181,7 @@ def pytest_pyfunc_call(pyfuncitem):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_fixture_setup(fixturedef, request):
     """
-    Need to make sure we process failed assumptions of setup failure as well, since pytest_pyfunc_call
+    Need to make sure we process failed assumptions of setup failures as well, since pytest_pyfunc_call
     does not get called if there's a setup failure.  Otherwise, failed assumptions will carry over to the
     next test case and the next test case will appear to fail with the previous test's failed assumptions.
     """
@@ -211,7 +211,7 @@ def handle_assumptions(outcome, in_setup=False):
         # If it's just a failed assumption in setup, save the failed assumption and let the test run.
         if outcome and outcome.excinfo:
             # Failed assumption(s) and other error(s)
-            del _FAILED_ASSUMPTIONS[:]  # Since we are raising, clear the failed assuption
+            del _FAILED_ASSUMPTIONS[:]  # Since we are raising, clear the failed assumption
             root_msg = "\nOriginal Failure:\n\n>> %s\n" % repr(outcome.excinfo[1]) + root_msg
             raise_(
                 FailedAssumption,

--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -194,7 +194,7 @@ def pytest_fixture_setup(fixturedef, request):
 
 def handle_assumptions(outcome, in_setup=False):
     """Look for and process failed assumptions from setup or test execution."""
-    __traceback_hide__ = True
+    __tracebackhide__ = True
     failed_assumptions = _FAILED_ASSUMPTIONS
     if failed_assumptions:
         failed_count = len(failed_assumptions)

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -101,9 +101,7 @@ def test_failing_expect_in_setup(testdir, assume_call):
         """.format(assume_call.format(
             expr="1==2",
             msg=None
-        ),
-            assume_call.format(expr="1==2",
-                               msg=None)))
+        )))
     result = testdir.runpytest_inprocess()
     result.assert_outcomes(passed=1,
                            skipped=0,
@@ -131,9 +129,7 @@ def test_multiple_failing_expect_in_setup(testdir, assume_call):
         """.format(assume_call.format(
             expr="1==2",
             msg=None
-        ),
-            assume_call.format(expr="1==2",
-                               msg=None)))
+        )))
     result = testdir.runpytest_inprocess()
     result.assert_outcomes(passed=0,
                            skipped=0,

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -52,6 +52,7 @@ def test_failing_expect(testdir, assume_call):
 
 
 def test_failing_expect_with_setup_error(testdir, assume_call):
+    """Setup has a failed assumption + error, test also has a failed assumption."""
     testdir.makepyfile(
         """
         import pytest
@@ -83,6 +84,7 @@ def test_failing_expect_with_setup_error(testdir, assume_call):
 
 
 def test_failing_expect_in_setup(testdir, assume_call):
+    """Setup has a failing assumption"""
     testdir.makepyfile(
         """
         import pytest

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -114,6 +114,35 @@ def test_failing_expect_in_setup(testdir, assume_call):
     assert "1 passed" in result.stdout.str()
 
 
+def test_multiple_failing_expect_in_setup(testdir, assume_call):
+    """Setup has a failing assumption, and 2 tests use the failing fixture."""
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def fixture_one():
+            {}
+
+        def test_func1(fixture_one):
+            pass
+
+        def test_func2(fixture_one):
+            pass
+        """.format(assume_call.format(
+            expr="1==2",
+            msg=None
+        ),
+            assume_call.format(expr="1==2",
+                               msg=None)))
+    result = testdir.runpytest_inprocess()
+    result.assert_outcomes(passed=0,
+                           skipped=0,
+                           failed=2,
+                           error=0)
+    assert "2 failed" in result.stdout.str()
+    assert result.stdout.str().count("1 Failed Assumption") == 2
+
+
 def test_multi_pass_one_failing_expect(testdir, assume_call):
     testdir.makepyfile(
         """

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -78,9 +78,10 @@ def test_failing_expect_with_setup_error(testdir, assume_call):
                            failed=0,
                            error=1)
     assert "1 error" in result.stdout.str()
+    # test_func1 won't run since its fixture has an error, so only 1 failed assumption
     assert "1 Failed Assumptions" in result.stdout.str()
     assert "1 passed" in result.stdout.str()
-    assert "ERROR at setup of test_func1" in result.stdout.str()
+    assert "setup error" in result.stdout.str()
 
 
 def test_failing_expect_in_setup(testdir, assume_call):
@@ -106,12 +107,11 @@ def test_failing_expect_in_setup(testdir, assume_call):
     result = testdir.runpytest_inprocess()
     result.assert_outcomes(passed=1,
                            skipped=0,
-                           failed=0,
-                           error=1)
-    assert "1 error" in result.stdout.str()
-    assert "1 Failed Assumptions" in result.stdout.str()
+                           failed=1,
+                           error=0)
+    assert "1 failed" in result.stdout.str()
+    assert "1 Failed Assumption" in result.stdout.str()
     assert "1 passed" in result.stdout.str()
-    assert "ERROR at setup of test_func1" in result.stdout.str()
 
 
 def test_multi_pass_one_failing_expect(testdir, assume_call):

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -51,6 +51,67 @@ def test_failing_expect(testdir, assume_call):
     assert "pytest_pyfunc_call" not in result.stdout.str()
 
 
+def test_failing_expect_with_setup_error(testdir, assume_call):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def fixture_one():
+            {}
+            raise Exception("setup error")
+
+        def test_func1(fixture_one):
+            {}
+
+        def test_func2():
+            pass
+        """.format(assume_call.format(
+            expr="1==2",
+            msg=None
+        ),
+            assume_call.format(expr="1==2",
+                               msg=None)))
+    result = testdir.runpytest_inprocess()
+    result.assert_outcomes(passed=1,
+                           skipped=0,
+                           failed=0,
+                           error=1)
+    assert "1 error" in result.stdout.str()
+    assert "1 Failed Assumptions" in result.stdout.str()
+    assert "1 passed" in result.stdout.str()
+    assert "ERROR at setup of test_func1" in result.stdout.str()
+
+
+def test_failing_expect_in_setup(testdir, assume_call):
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.fixture
+        def fixture_one():
+            {}
+
+        def test_func1(fixture_one):
+            pass
+
+        def test_func2():
+            pass
+        """.format(assume_call.format(
+            expr="1==2",
+            msg=None
+        ),
+            assume_call.format(expr="1==2",
+                               msg=None)))
+    result = testdir.runpytest_inprocess()
+    result.assert_outcomes(passed=1,
+                           skipped=0,
+                           failed=0,
+                           error=1)
+    assert "1 error" in result.stdout.str()
+    assert "1 Failed Assumptions" in result.stdout.str()
+    assert "1 passed" in result.stdout.str()
+    assert "ERROR at setup of test_func1" in result.stdout.str()
+
+
 def test_multi_pass_one_failing_expect(testdir, assume_call):
     testdir.makepyfile(
         """

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -139,6 +139,33 @@ def test_multiple_failing_expect_in_setup(testdir, assume_call):
     assert result.stdout.str().count("1 Failed Assumption") == 2
 
 
+def test_multiple_failing_expect_in_module_scope_fixture(testdir, assume_call):
+    """Module-scope fixture has a failing assumption, and 2 tests use the failing fixture."""
+    testdir.makepyfile(
+        """
+        import pytest
+        @pytest.fixture(scope='module')
+        def fixture_one():
+            {}
+
+        def test_func1(fixture_one):
+            pass
+
+        def test_func2(fixture_one):
+            pass
+        """.format(assume_call.format(
+            expr="1==2",
+            msg=None
+        )))
+    result = testdir.runpytest_inprocess()
+    result.assert_outcomes(passed=1,
+                           skipped=0,
+                           failed=1,
+                           error=0)
+    assert "1 failed" in result.stdout.str()
+    assert "1 Failed Assumption" in result.stdout.str()
+
+
 def test_multi_pass_one_failing_expect(testdir, assume_call):
     testdir.makepyfile(
         """


### PR DESCRIPTION
If there is a failed assumption in setup, make sure it gets logged with the test run.
If there is a failed assumption & an error in setup, make sure that the failed assumption is reported for this test, not the subsequent one.

This addresses #29 .  I believe it also addresses #13 with the desired behavior.
