### PR TITLE
Fix crash when making a path relative (Windows)

### DIFF
--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -74,7 +74,10 @@ class AssumeContextManager(object):
         stack_level = 2 if self._enter_from_call else 1
         (frame, filename, line, funcname, contextlist) = inspect.stack()[stack_level][0:5]
         # get filename, line, and context
-        filename = os.path.relpath(filename)
+        try:
+            filename = os.path.relpath(filename)
+        except ValueError:
+            pass	# filename is on a different mount than the current dir (Windows)
 
         context = "" if contextlist is None else contextlist[0].lstrip()
 


### PR DESCRIPTION
When the Python source file containing the pytest.assume() call is on a different drive than the current directory, os.path.relpath raises an exception. Just use the absolute filename in this case.

Example of pytest failing before applying this patch:
```
out_filename = 'subdir'
output_dir = path('C:\\Users\\Brecht\\AppData\\Local\\Temp\\pytest-of-unknown\\pytest-7\\subdir\\_build\\rinoh')
reference_path = path('O:\\rinohtype\\tests_regression\\roots')

    def verify_output(out_filename, output_dir, reference_path):
        pdf_filename = '{}.pdf'.format(out_filename)
        _, _, _, _, _, _, ref_outlines = \
            check_pdf_links(reference_path / pdf_filename)
        with in_directory(output_dir):
            _, _, _, badlinks, _, _, outlines = check_pdf_links(pdf_filename)
>           pytest.assume(badlinks == [])

tests_regression\helpers\regression.py:131:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pytest_assume.plugin.AssumeContextManager object at 0x00000232C2188760>, expr = True, msg = ''

    def __call__(self, expr, msg=""):
        __tracebackhide__ = True
        self._enter_from_call = True
        with self:
            if msg:
                assert expr, msg
            else:
>               assert expr

c:\users\brecht\documents\code\pytest-assume\pytest_assume\plugin.py:121:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pytest_assume.plugin.AssumeContextManager object at 0x00000232C2188760>, exc_type = None, exc_val = None
exc_tb = None

    def __exit__(self, exc_type, exc_val, exc_tb):
        __tracebackhide__ = True
        pretty_locals = None
        entry = None
        tb = None
        stack_level = 2 if self._enter_from_call else 1
        (frame, filename, line, funcname, contextlist) = inspect.stack()[stack_level][0:5]
        # get filename, line, and context
>       filename = os.path.relpath(filename)

c:\users\brecht\documents\code\pytest-assume\pytest_assume\plugin.py:77:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = 'O:\\rinohtype\\tests_regression\\helpers\\regression.py', start = '.'

    def relpath(path, start=None):
        """Return a relative version of a path"""
        path = os.fspath(path)
        if isinstance(path, bytes):
            sep = b'\\'
            curdir = b'.'
            pardir = b'..'
        else:
            sep = '\\'
            curdir = '.'
            pardir = '..'

        if start is None:
            start = curdir

        if not path:
            raise ValueError("no path specified")

        start = os.fspath(start)
        try:
            start_abs = abspath(normpath(start))
            path_abs = abspath(normpath(path))
            start_drive, start_rest = splitdrive(start_abs)
            path_drive, path_rest = splitdrive(path_abs)
            if normcase(start_drive) != normcase(path_drive):
>               raise ValueError("path is on mount %r, start on mount %r" % (
                    path_drive, start_drive))
E                   ValueError: path is on mount 'O:', start on mount 'C:'

C:\Python38\lib\ntpath.py:703: ValueError
```