### PR TITLE
Tweaked original failure formatting to align with assumption messages better

### DIFF
--- a/pytest_assume/plugin.py
+++ b/pytest_assume/plugin.py
@@ -241,7 +241,9 @@ def pytest_runtest_call(item):
                 if "[XPASS(strict)]" in str(outcome.excinfo[1]):
                     restore_xfail(item)
                     raise_(FailedAssumption, FailedAssumption("%s\n%s" % (root_msg, content)), last_tb)
-                root_msg = "\nOriginal Failure:\n\n>> %s\n" % repr(outcome.excinfo[1]) + root_msg
+                # Note: code traceback should already be printed above, this is to stay consistent
+                original_failure = "%s: %s" % (outcome.excinfo[0].__name__, str(outcome.excinfo[1]))
+                root_msg = "\nOriginal Failure:\n\n%s\n" % original_failure + root_msg
                 raise_(
                     FailedAssumption,
                     FailedAssumption(root_msg + "\n" + content),


### PR DESCRIPTION
I'm not sure if the format it's been in was very intentional, but I figured having it more in sync with how pytest prints the original failure messages normally made more sense, also more for the use-case of having "thirdparty" reporters work with the generated message better.
Original failure doesn't have any tests, so I didn't touch those.